### PR TITLE
circleci: optimize bazel runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,19 +264,11 @@ jobs:
             ./bazel-bin/bb_/bb helloworld
       - run:
           name: build everything (amd64)
-          command: cd src && bazel build //...
-      - run:
-          name: build arm64
           command: |
             cd src
+            bazel build //...
             bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //:uroot_bb
             bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //:bb
-      - run:
-          name: build arm
-          command: |
-            cd src
             bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm //:uroot_bb
             bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm //:bb
-      - run:
-          name: test everything
-          command: cd src && bazel test //...
+            bazel test //...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,12 @@ workflows:
       - build-bazel:
           requires:
             - clean-bazel
+      - build-bazel-cross:
+          requires:
+            - clean-bazel
+      - build-bazel-test:
+          requires:
+            - clean-bazel
 
 jobs:
   clean-makebb:
@@ -268,8 +274,26 @@ jobs:
           command: |
             cd src
             bazel build //...
+
+  build-bazel-cross:
+    <<: *bazel-template
+    steps:
+      - checkout
+      - run:
+          name: bazel cross-compile
+          command: |
+            cd src
             bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //:uroot_bb
             bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //:bb
             bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm //:uroot_bb
             bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm //:bb
+
+  build-bazel-test:
+    <<: *bazel-template
+    steps:
+      - checkout
+      - run:
+          name: bazel test
+          command: |
+            cd src
             bazel test //...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ templates:
     working_directory: /go/bazel_gobusybox
     environment:
       - GOPATH: "/go"
+    resource_class: xlarge
 
   build-gomod-template: &build-gomod-template
     steps:


### PR DESCRIPTION
bazel is taking 15 minutes to build and test everything on circleci: https://app.circleci.com/pipelines/github/u-root/gobusybox/178/workflows/6709863c-d97b-478c-9914-c2f82a786262

That's crazy. Let's see if batching them allows for more bazel caching... otherwise, I'll split them into separate containers that can run in parallel.