### PR TITLE
Split bbinternal package

### DIFF
--- a/src/pkg/bb/BUILD.bazel
+++ b/src/pkg/bb/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/pkg/bb/bbinternal",
+        "//src/pkg/bb/findpkg",
         "//src/pkg/golang",
         "@com_github_google_goterm//term",
         "@com_github_u_root_uio//cp",

--- a/src/pkg/bb/bb.go
+++ b/src/pkg/bb/bb.go
@@ -115,13 +115,13 @@ func BuildBusybox(opts *Opts) (nerr error) {
 		dirents, err := ioutil.ReadDir(opts.GenSrcDir)
 		if os.IsNotExist(err) {
 			if err := os.MkdirAll(opts.GenSrcDir, 0700); err != nil {
-				return fmt.Errorf("could not create busybox generated source directory: %w", err)
+				return fmt.Errorf("could not create directory for busybox generated source: %w", err)
 			}
 			relTmpDir = opts.GenSrcDir
 		} else if err != nil {
-			return fmt.Errorf("could not read busybox generated source directory: %w", err)
+			return fmt.Errorf("could not read directory supplied for busybox generated source: %w", err)
 		} else if len(dirents) > 0 {
-			return fmt.Errorf("busybox generated source directory is not an empty directory")
+			return fmt.Errorf("directory supplied for busybox generated source is not an empty directory")
 		} else {
 			relTmpDir = opts.GenSrcDir
 		}

--- a/src/pkg/bb/bb.go
+++ b/src/pkg/bb/bb.go
@@ -39,6 +39,7 @@ import (
 	"golang.org/x/tools/go/packages"
 
 	"github.com/u-root/gobusybox/src/pkg/bb/bbinternal"
+	"github.com/u-root/gobusybox/src/pkg/bb/findpkg"
 	"github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/uio/cp"
 )
@@ -151,7 +152,7 @@ func BuildBusybox(opts *Opts) (nerr error) {
 	pkgDir := filepath.Join(tmpDir, "src")
 
 	// Ask go about all the commands in one batch for dependency caching.
-	cmds, err := bbinternal.NewPackages(opts.Env, opts.CommandPaths...)
+	cmds, err := findpkg.NewPackages(opts.Env, opts.CommandPaths...)
 	if err != nil {
 		return fmt.Errorf("finding packages failed: %v", err)
 	}

--- a/src/pkg/bb/bbinternal/BUILD.bazel
+++ b/src/pkg/bb/bbinternal/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "bbinternal",
@@ -6,17 +6,9 @@ go_library(
     importpath = "github.com/u-root/gobusybox/src/pkg/bb/bbinternal",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/pkg/golang",
         "@com_github_u_root_uio//cp",
-        "@org_golang_x_sys//unix",
         "@org_golang_x_tools//go/ast/astutil",
         "@org_golang_x_tools//go/packages",
         "@org_golang_x_tools//imports",
     ],
-)
-
-go_test(
-    name = "bbinternal_test",
-    srcs = ["bb_test.go"],
-    embed = [":bbinternal"],
 )

--- a/src/pkg/bb/bbinternal/bb.go
+++ b/src/pkg/bb/bbinternal/bb.go
@@ -11,7 +11,6 @@ package bbinternal
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/format"
@@ -19,7 +18,6 @@ import (
 	"go/token"
 	"go/types"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -28,12 +26,10 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/sys/unix"
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/imports"
 
-	"github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/uio/cp"
 )
 
@@ -127,218 +123,6 @@ type Package struct {
 	//
 	// The key Expr must also be the AssignStmt.Rhs[0].
 	initAssigns map[ast.Expr]ast.Stmt
-}
-
-// modules returns a list of module directories => directories of packages
-// inside that module as well as packages that have no discernible module.
-//
-// The module for a package is determined by the **first** parent directory
-// that contains a go.mod.
-func modules(filesystemPaths []string) (map[string][]string, []string) {
-	// list of module directory => directories of packages it likely contains
-	moduledPackages := make(map[string][]string)
-	var noModulePkgs []string
-	for _, fullPath := range filesystemPaths {
-		components := strings.Split(fullPath, "/")
-
-		inModule := false
-		for i := len(components); i >= 1; i-- {
-			prefixPath := "/" + filepath.Join(components[:i]...)
-			if _, err := os.Stat(filepath.Join(prefixPath, "go.mod")); err == nil {
-				moduledPackages[prefixPath] = append(moduledPackages[prefixPath], fullPath)
-				inModule = true
-				break
-			}
-		}
-		if !inModule {
-			noModulePkgs = append(noModulePkgs, fullPath)
-		}
-	}
-	return moduledPackages, noModulePkgs
-}
-
-// We load file system paths differently, because there is a big difference between
-//
-//    go list -json ../../foobar
-//
-// and
-//
-//    (cd ../../foobar && go list -json .)
-//
-// Namely, PWD determines which go.mod to use. We want each
-// package to use its own go.mod, if it has one.
-func loadFSPackages(env golang.Environ, filesystemPaths []string) ([]*packages.Package, error) {
-	var absPaths []string
-	for _, fsPath := range filesystemPaths {
-		absPath, err := filepath.Abs(fsPath)
-		if err != nil {
-			return nil, fmt.Errorf("could not find package at %q", fsPath)
-		}
-		absPaths = append(absPaths, absPath)
-	}
-
-	var allps []*packages.Package
-
-	// Find each packages' module, and batch package queries together by module.
-	//
-	// Query all packages that don't have a module at all together, as well.
-	//
-	// Batching these queries saves a *lot* of time; on the order of
-	// several minutes for 30+ commands.
-	mods, noModulePkgDirs := modules(absPaths)
-
-	for moduleDir, pkgDirs := range mods {
-		pkgs, err := loadFSPkgs(env, moduleDir, pkgDirs...)
-		if err != nil {
-			return nil, fmt.Errorf("could not find packages in module %s: %v", moduleDir, err)
-		}
-		for _, pkg := range pkgs {
-			allps = addPkg(allps, pkg)
-		}
-	}
-
-	if len(noModulePkgDirs) > 0 {
-		// The directory we choose can be any dir that does not have a
-		// go.mod anywhere in its parent tree.
-		vendoredPkgs, err := loadFSPkgs(env, noModulePkgDirs[0], noModulePkgDirs...)
-		if err != nil {
-			return nil, fmt.Errorf("could not find packages: %v", err)
-		}
-		for _, p := range vendoredPkgs {
-			allps = addPkg(allps, p)
-		}
-	}
-	return allps, nil
-}
-
-func addPkg(plist []*packages.Package, p *packages.Package) []*packages.Package {
-	if len(p.Errors) > 0 {
-		// TODO(chrisko): should we return an error here instead of warn?
-		log.Printf("Skipping package %v for errors:", p)
-		packages.PrintErrors([]*packages.Package{p})
-	} else if len(p.GoFiles) == 0 {
-		log.Printf("Skipping package %v because it has no Go files", p)
-	} else if p.Name != "main" {
-		log.Printf("Skipping package %v because it is not a command (must be `package main`)", p)
-	} else {
-		plist = append(plist, p)
-	}
-	return plist
-}
-
-// NewPackages collects package metadata about all named packages.
-//
-// names can either be directory paths or Go import paths.
-func NewPackages(env golang.Environ, names ...string) ([]*Package, error) {
-	var goImportPaths []string
-	var filesystemPaths []string
-
-	for _, name := range names {
-		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "/") {
-			filesystemPaths = append(filesystemPaths, name)
-		} else if _, err := os.Stat(name); err == nil {
-			filesystemPaths = append(filesystemPaths, name)
-		} else {
-			goImportPaths = append(goImportPaths, name)
-		}
-	}
-
-	var ps []*packages.Package
-	if len(goImportPaths) > 0 {
-		importPkgs, err := loadPkgs(env, "", goImportPaths...)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load package %v: %v", goImportPaths, err)
-		}
-		for _, p := range importPkgs {
-			ps = addPkg(ps, p)
-		}
-	}
-
-	pkgs, err := loadFSPackages(env, filesystemPaths)
-	if err != nil {
-		return nil, fmt.Errorf("could not load packages from file system: %v", err)
-	}
-	ps = append(ps, pkgs...)
-
-	var ips []*Package
-	for _, p := range ps {
-		ips = append(ips, NewPackage(path.Base(p.PkgPath), p))
-	}
-	return ips, nil
-}
-
-// loadFSPkgs looks up importDirs packages, making the import path relative to
-// `dir`. `go list -json` requires the import path to be relative to the dir
-// when the package is outside of a $GOPATH and there is no go.mod in any parent directory.
-func loadFSPkgs(env golang.Environ, dir string, importDirs ...string) ([]*packages.Package, error) {
-	// Eligibility check: does each directory contain files that are
-	// compilable under the current GOROOT/GOPATH/GOOS/GOARCH and build
-	// tags?
-	//
-	// In Go 1.14 and Go 1.15, this is done by packages.Load on a
-	// per-package basis, which is why batching queries works out well. In
-	// Go 1.13, the entire query fails with no indication of which package
-	// made it fail, so we need to filter out commands that do not have
-	// compilable files first.
-	var compilableImportDirs []string
-	for _, importDir := range importDirs {
-		f, err := os.Open(importDir)
-		if err != nil {
-			return nil, err
-		}
-		names, err := f.Readdirnames(0)
-		if errors.Is(err, unix.ENOTDIR) {
-			return nil, fmt.Errorf("Go busybox requires a list of directories; failed to read directory %s: %v", importDir, err)
-		} else if err != nil {
-			return nil, fmt.Errorf("could not determine file names for %s: %v", importDir, err)
-		}
-		foundOne := false
-		for _, name := range names {
-			if match, err := env.Context.MatchFile(importDir, name); err != nil {
-				// This pretty much only returns an error if
-				// the file cannot be opened or read.
-				return nil, fmt.Errorf("could not determine Go build constraints of %s: %v", importDir, err)
-			} else if match {
-				foundOne = true
-				break
-			}
-		}
-		if foundOne {
-			compilableImportDirs = append(compilableImportDirs, importDir)
-		} else {
-			log.Printf("Skipping directory %s because build constraints exclude all Go files", importDir)
-		}
-	}
-
-	if len(compilableImportDirs) == 0 {
-		return nil, fmt.Errorf("build constraints excluded all requested commands")
-	}
-
-	// Make all paths relative, because packages.Load/`go list -json` does
-	// not like absolute paths sometimes.
-	var relImportDirs []string
-	for _, importDir := range compilableImportDirs {
-		relImportDir, err := filepath.Rel(dir, importDir)
-		if err != nil {
-			return nil, fmt.Errorf("Go package path %s is not relative to %s: %v", importDir, dir, err)
-		}
-
-		// N.B. `go list -json cmd/foo` is not the same as `go list -json ./cmd/foo`.
-		//
-		// The former looks for cmd/foo in $GOROOT or $GOPATH, while
-		// the latter looks in the relative directory ./cmd/foo.
-		relImportDirs = append(relImportDirs, "./"+relImportDir)
-	}
-	return loadPkgs(env, dir, relImportDirs...)
-}
-
-func loadPkgs(env golang.Environ, dir string, patterns ...string) ([]*packages.Package, error) {
-	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedImports | packages.NeedFiles | packages.NeedDeps | packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedCompiledGoFiles | packages.NeedModule,
-		Env:  append(os.Environ(), env.Env()...),
-		Dir:  dir,
-	}
-	return packages.Load(cfg, patterns...)
 }
 
 // NewPackage creates a new Package based on an existing packages.Package.

--- a/src/pkg/bb/findpkg/BUILD.bazel
+++ b/src/pkg/bb/findpkg/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "findpkg",
+    srcs = ["bb.go"],
+    importpath = "github.com/u-root/gobusybox/src/pkg/bb/findpkg",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/pkg/bb/bbinternal",
+        "//src/pkg/golang",
+        "@org_golang_x_sys//unix",
+        "@org_golang_x_tools//go/packages",
+    ],
+)
+
+go_test(
+    name = "findpkg_test",
+    srcs = ["bb_test.go"],
+    embed = [":findpkg"],
+)

--- a/src/pkg/bb/findpkg/bb.go
+++ b/src/pkg/bb/findpkg/bb.go
@@ -1,0 +1,235 @@
+// Copyright 2015-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package findpkg finds packages from user-input strings that are either file
+// paths or Go package paths.
+package findpkg
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/tools/go/packages"
+
+	"github.com/u-root/gobusybox/src/pkg/bb/bbinternal"
+	"github.com/u-root/gobusybox/src/pkg/golang"
+)
+
+// modules returns a list of module directories => directories of packages
+// inside that module as well as packages that have no discernible module.
+//
+// The module for a package is determined by the **first** parent directory
+// that contains a go.mod.
+func modules(filesystemPaths []string) (map[string][]string, []string) {
+	// list of module directory => directories of packages it likely contains
+	moduledPackages := make(map[string][]string)
+	var noModulePkgs []string
+	for _, fullPath := range filesystemPaths {
+		components := strings.Split(fullPath, "/")
+
+		inModule := false
+		for i := len(components); i >= 1; i-- {
+			prefixPath := "/" + filepath.Join(components[:i]...)
+			if _, err := os.Stat(filepath.Join(prefixPath, "go.mod")); err == nil {
+				moduledPackages[prefixPath] = append(moduledPackages[prefixPath], fullPath)
+				inModule = true
+				break
+			}
+		}
+		if !inModule {
+			noModulePkgs = append(noModulePkgs, fullPath)
+		}
+	}
+	return moduledPackages, noModulePkgs
+}
+
+// We load file system paths differently, because there is a big difference between
+//
+//    go list -json ../../foobar
+//
+// and
+//
+//    (cd ../../foobar && go list -json .)
+//
+// Namely, PWD determines which go.mod to use. We want each
+// package to use its own go.mod, if it has one.
+func loadFSPackages(env golang.Environ, filesystemPaths []string) ([]*packages.Package, error) {
+	var absPaths []string
+	for _, fsPath := range filesystemPaths {
+		absPath, err := filepath.Abs(fsPath)
+		if err != nil {
+			return nil, fmt.Errorf("could not find package at %q", fsPath)
+		}
+		absPaths = append(absPaths, absPath)
+	}
+
+	var allps []*packages.Package
+
+	// Find each packages' module, and batch package queries together by module.
+	//
+	// Query all packages that don't have a module at all together, as well.
+	//
+	// Batching these queries saves a *lot* of time; on the order of
+	// several minutes for 30+ commands.
+	mods, noModulePkgDirs := modules(absPaths)
+
+	for moduleDir, pkgDirs := range mods {
+		pkgs, err := loadFSPkgs(env, moduleDir, pkgDirs...)
+		if err != nil {
+			return nil, fmt.Errorf("could not find packages in module %s: %v", moduleDir, err)
+		}
+		for _, pkg := range pkgs {
+			allps = addPkg(allps, pkg)
+		}
+	}
+
+	if len(noModulePkgDirs) > 0 {
+		// The directory we choose can be any dir that does not have a
+		// go.mod anywhere in its parent tree.
+		vendoredPkgs, err := loadFSPkgs(env, noModulePkgDirs[0], noModulePkgDirs...)
+		if err != nil {
+			return nil, fmt.Errorf("could not find packages: %v", err)
+		}
+		for _, p := range vendoredPkgs {
+			allps = addPkg(allps, p)
+		}
+	}
+	return allps, nil
+}
+
+func addPkg(plist []*packages.Package, p *packages.Package) []*packages.Package {
+	if len(p.Errors) > 0 {
+		// TODO(chrisko): should we return an error here instead of warn?
+		log.Printf("Skipping package %v for errors:", p)
+		packages.PrintErrors([]*packages.Package{p})
+	} else if len(p.GoFiles) == 0 {
+		log.Printf("Skipping package %v because it has no Go files", p)
+	} else if p.Name != "main" {
+		log.Printf("Skipping package %v because it is not a command (must be `package main`)", p)
+	} else {
+		plist = append(plist, p)
+	}
+	return plist
+}
+
+// NewPackages collects package metadata about all named packages.
+//
+// names can either be directory paths or Go import paths.
+func NewPackages(env golang.Environ, names ...string) ([]*bbinternal.Package, error) {
+	var goImportPaths []string
+	var filesystemPaths []string
+
+	for _, name := range names {
+		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "/") {
+			filesystemPaths = append(filesystemPaths, name)
+		} else if _, err := os.Stat(name); err == nil {
+			filesystemPaths = append(filesystemPaths, name)
+		} else {
+			goImportPaths = append(goImportPaths, name)
+		}
+	}
+
+	var ps []*packages.Package
+	if len(goImportPaths) > 0 {
+		importPkgs, err := loadPkgs(env, "", goImportPaths...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load package %v: %v", goImportPaths, err)
+		}
+		for _, p := range importPkgs {
+			ps = addPkg(ps, p)
+		}
+	}
+
+	pkgs, err := loadFSPackages(env, filesystemPaths)
+	if err != nil {
+		return nil, fmt.Errorf("could not load packages from file system: %v", err)
+	}
+	ps = append(ps, pkgs...)
+
+	var ips []*bbinternal.Package
+	for _, p := range ps {
+		ips = append(ips, bbinternal.NewPackage(path.Base(p.PkgPath), p))
+	}
+	return ips, nil
+}
+
+// loadFSPkgs looks up importDirs packages, making the import path relative to
+// `dir`. `go list -json` requires the import path to be relative to the dir
+// when the package is outside of a $GOPATH and there is no go.mod in any parent directory.
+func loadFSPkgs(env golang.Environ, dir string, importDirs ...string) ([]*packages.Package, error) {
+	// Eligibility check: does each directory contain files that are
+	// compilable under the current GOROOT/GOPATH/GOOS/GOARCH and build
+	// tags?
+	//
+	// In Go 1.14 and Go 1.15, this is done by packages.Load on a
+	// per-package basis, which is why batching queries works out well. In
+	// Go 1.13, the entire query fails with no indication of which package
+	// made it fail, so we need to filter out commands that do not have
+	// compilable files first.
+	var compilableImportDirs []string
+	for _, importDir := range importDirs {
+		f, err := os.Open(importDir)
+		if err != nil {
+			return nil, err
+		}
+		names, err := f.Readdirnames(0)
+		if errors.Is(err, unix.ENOTDIR) {
+			return nil, fmt.Errorf("Go busybox requires a list of directories; failed to read directory %s: %v", importDir, err)
+		} else if err != nil {
+			return nil, fmt.Errorf("could not determine file names for %s: %v", importDir, err)
+		}
+		foundOne := false
+		for _, name := range names {
+			if match, err := env.Context.MatchFile(importDir, name); err != nil {
+				// This pretty much only returns an error if
+				// the file cannot be opened or read.
+				return nil, fmt.Errorf("could not determine Go build constraints of %s: %v", importDir, err)
+			} else if match {
+				foundOne = true
+				break
+			}
+		}
+		if foundOne {
+			compilableImportDirs = append(compilableImportDirs, importDir)
+		} else {
+			log.Printf("Skipping directory %s because build constraints exclude all Go files", importDir)
+		}
+	}
+
+	if len(compilableImportDirs) == 0 {
+		return nil, fmt.Errorf("build constraints excluded all requested commands")
+	}
+
+	// Make all paths relative, because packages.Load/`go list -json` does
+	// not like absolute paths sometimes.
+	var relImportDirs []string
+	for _, importDir := range compilableImportDirs {
+		relImportDir, err := filepath.Rel(dir, importDir)
+		if err != nil {
+			return nil, fmt.Errorf("Go package path %s is not relative to %s: %v", importDir, dir, err)
+		}
+
+		// N.B. `go list -json cmd/foo` is not the same as `go list -json ./cmd/foo`.
+		//
+		// The former looks for cmd/foo in $GOROOT or $GOPATH, while
+		// the latter looks in the relative directory ./cmd/foo.
+		relImportDirs = append(relImportDirs, "./"+relImportDir)
+	}
+	return loadPkgs(env, dir, relImportDirs...)
+}
+
+func loadPkgs(env golang.Environ, dir string, patterns ...string) ([]*packages.Package, error) {
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedImports | packages.NeedFiles | packages.NeedDeps | packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedCompiledGoFiles | packages.NeedModule,
+		Env:  append(os.Environ(), env.Env()...),
+		Dir:  dir,
+	}
+	return packages.Load(cfg, patterns...)
+}

--- a/src/pkg/bb/findpkg/bb_test.go
+++ b/src/pkg/bb/findpkg/bb_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package bbinternal
+package findpkg
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
part 1: bbinternal remains the stuff shared between bazel and standard
Go, the stuff that modifies AST, parses & writes Go files, and creates a
main.go.

part 2: findpkg turns a list of user-input package names/globs into
Packages we know.

Signed-off-by: Chris Koch <chrisko@google.com>