### PR TITLE
makebb: and a generate code but do not build switch

### DIFF
--- a/src/cmd/makebb/makebb.go
+++ b/src/cmd/makebb/makebb.go
@@ -20,6 +20,7 @@ import (
 var (
 	outputPath = flag.String("o", "bb", "Path to compiled busybox binary")
 	genDir     = flag.String("gen-dir", "", "Directory to generate source in")
+	genOnly    = flag.Bool("g", false, "Generate but do not build binaries")
 )
 
 func main() {
@@ -59,6 +60,7 @@ func main() {
 		CommandPaths: flag.Args(),
 		BinaryPath:   o,
 		GoBuildOpts:  bopts,
+		GenerateOnly: *genOnly,
 	}
 	if err := bb.BuildBusybox(opts); err != nil {
 		l.Print(err)
@@ -71,9 +73,11 @@ func main() {
 		} else {
 			l.Fatalf("Preserving bb generated source directory at %s due to error.", tmpDir)
 		}
+	} else if opts.GenerateOnly {
+		l.Printf("Generated source can be found in %s. `cd %s && go build` to build.", tmpDir, filepath.Join(tmpDir, "src/bb.u-root.com/bb"))
 	}
 	// Only remove temp dir if there was no error.
-	if remove {
+	if remove && !opts.GenerateOnly {
 		os.RemoveAll(tmpDir)
 	}
 }

--- a/src/pkg/bb/bb.go
+++ b/src/pkg/bb/bb.go
@@ -96,6 +96,10 @@ type Opts struct {
 	//
 	// If this is done with GO111MODULE=on,
 	AllowMixedMode bool
+
+	// Generate the tree but don't build it. This is useful for systems
+	// like Tamago which have their own way of building.
+	GenerateOnly bool
 }
 
 // BuildBusybox builds a busybox of many Go commands. opts contains both the
@@ -132,6 +136,9 @@ func BuildBusybox(opts *Opts) (nerr error) {
 		}
 		tmpDir = absDir
 	} else {
+		if opts.GenerateOnly {
+			return fmt.Errorf("GenerateOnly switch requires that the GenSrcDir directory be supplied")
+		}
 		var err error
 		tmpDir, err = ioutil.TempDir("", "bb-")
 		if err != nil {
@@ -216,6 +223,10 @@ func BuildBusybox(opts *Opts) (nerr error) {
 		if o, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("running `go mod tidy` on the generated busybox main package failed (%v): %s", err, o)
 		}
+	}
+
+	if opts.GenerateOnly {
+		return nil
 	}
 
 	// Compile bb.


### PR DESCRIPTION
-g will allow the package to generate code but not compile it.

Systems like tamago are not quite in reach for makebb to build just yet.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>