### PR TITLE
Fix failing Go module builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ templates:
     docker:
       - image: circleci/golang:1.16
 
+  go117-template: &go117-template
+    docker:
+      - image: circleci/golang:1.17
+
   bazel-template: &bazel-template
     docker:
       - image: l.gcr.io/google/bazel:latest
@@ -96,6 +100,10 @@ workflows:
           requires:
             - clean-makebb
             - clean-gopath
+      - build-gopath-go117:
+          requires:
+            - clean-makebb
+            - clean-gopath
       - build-gomod-go113:
           requires:
             - clean-makebb
@@ -109,6 +117,10 @@ workflows:
             - clean-makebb
             - clean-gomod
       - build-gomod-go116:
+          requires:
+            - clean-makebb
+            - clean-gomod
+      - build-gomod-go117:
           requires:
             - clean-makebb
             - clean-gomod
@@ -134,17 +146,19 @@ workflows:
       - build-gopath-go114
       - build-gopath-go115
       - build-gopath-go116
+      - build-gopath-go117
       - build-gomod-go113
       - build-gomod-go114
       - build-gomod-go115
       - build-gomod-go116
+      - build-gomod-go117
       - build-bazel
       - build-bazel-cross
       - build-bazel-test
 
 jobs:
   clean-makebb:
-    <<: [*go116-template, *gomod-template]
+    <<: [*go117-template, *gomod-template]
     steps:
       - checkout
       - run:
@@ -165,7 +179,7 @@ jobs:
             fi
 
   clean-gopath:
-    <<: [*go116-template, *gopath-template]
+    <<: [*go117-template, *gopath-template]
     steps:
       - checkout
       - run:
@@ -209,8 +223,11 @@ jobs:
   build-gopath-go116:
     <<: [*go116-template, *gopath-template, *build-gopath-template]
 
+  build-gopath-go117:
+    <<: [*go117-template, *gopath-template, *build-gopath-template]
+
   clean-gomod:
-    <<: [*go116-template, *gomod-template]
+    <<: [*go117-template, *gomod-template]
     steps:
       - checkout
       - run:
@@ -267,6 +284,9 @@ jobs:
 
   build-gomod-go116:
     <<: [*go116-template, *gomod-template, *build-gomod-template]
+
+  build-gomod-go117:
+    <<: [*go117-template, *gomod-template, *build-gomod-template]
 
   clean-bazel:
     <<: *bazel-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,14 @@ templates:
           name: gobuilds
           command: ./gobuilds.sh
       - run:
-          name: build u-root & u-bmc & gokrazy & p9
+          name: build gokrazy & p9 together
+          command: ./test-multi-simple.sh
+
+  build-gomod-multi-template: &build-gomod-multi-template
+    steps:
+      - checkout
+      - run:
+          name: build u-root & gokrazy & p9 together
           command: ./test-external.sh
 
   build-gopath-template: &build-gopath-template
@@ -124,6 +131,10 @@ workflows:
           requires:
             - clean-makebb
             - clean-gomod
+      - build-gomod-multi-go117:
+          requires:
+            - clean-makebb
+            - clean-gomod
       - build-bazel:
           requires:
             - clean-bazel
@@ -152,6 +163,7 @@ workflows:
       - build-gomod-go115
       - build-gomod-go116
       - build-gomod-go117
+      - build-gomod-multi-go117
       - build-bazel
       - build-bazel-cross
       - build-bazel-test
@@ -287,6 +299,9 @@ jobs:
 
   build-gomod-go117:
     <<: [*go117-template, *gomod-template, *build-gomod-template]
+
+  build-gomod-multi-go117:
+    <<: [*go117-template, *gomod-template, *build-gomod-multi-template]
 
   clean-bazel:
     <<: *bazel-template

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ determine which command is being called.
 
 | Feature    | Support status                                        |
 | ---------- | ----------------------------------------------------- |
-| Go version | Tested are 1.13-1.16                                  |
+| Go version | Tested are 1.13-1.17                                  |
 | Packaging  | Go modules, Go vendoring, bazel w/ [rules_go](https\://github.com/bazelbuild/rules_go) |
 | `GOOS`     | linux (others may work, but untested)                 |
 | `GOARCH`   | amd64, arm, arm64, riscv64 (others may work, but untested) |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,8 +36,11 @@ go_embed_data_dependencies()
 
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+    sha256 = "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a",
+    strip_prefix = "protobuf-3.13.0",
+    urls = [
+        "https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz",
+    ],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -46,8 +49,11 @@ protobuf_deps()
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-master",
-    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
+    sha256 = "ae34c344514e08c23e90da0e2d6cb700fcd28e80c02e23e4d5715dddcb42f7b3",
+    strip_prefix = "buildtools-4.2.2",
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.2.2.tar.gz",
+    ],
 )
 
 load("@bazel_gazelle//:deps.bzl", "go_repository")

--- a/test-external.sh
+++ b/test-external.sh
@@ -26,7 +26,7 @@ function ctrl_c() {
 trap ctrl_c INT
 
 # u-root checked out NOT in $GOPATH.
-(cd $TMPDIR && git clone --branch circ-dep https://github.com/hugelgupf/u-root)
+(cd $TMPDIR && git clone https://github.com/u-root/u-root)
 (cd $TMPDIR && git clone https://github.com/gokrazy/gokrazy)
 (cd $TMPDIR && git clone https://github.com/hugelgupf/p9)
 

--- a/test-multi-simple.sh
+++ b/test-multi-simple.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -ex
+
+if [ -z "$GOROOT" ]; then
+  GO="go"
+else
+  GO="$GOROOT/bin/go"
+fi
+
+cd src/cmd/makebb
+
+$GO generate
+$GO build
+
+cd ../../..
+
+TMPDIR=$(mktemp -d)
+EMPTY_TMPDIR=$(mktemp -d)
+
+function ctrl_c() {
+  rm -rf $TMPDIR
+  # https://github.com/golang/go/issues/27455
+  GOPATH=$EMPTY_TMPDIR $GO clean -cache -modcache
+  rm -rf $EMPTY_TMPDIR
+}
+trap ctrl_c INT
+
+(cd $TMPDIR && git clone https://github.com/gokrazy/gokrazy)
+(cd $TMPDIR && git clone https://github.com/hugelgupf/p9)
+
+# Compile gokrazy and p9 together. Got ideas for what to add here? Let me know.
+GOROOT=$GOROOT GOPATH=$EMPTY_TMPDIR GO111MODULE=on ./src/cmd/makebb/makebb $TMPDIR/gokrazy/cmd/* $TMPDIR/p9/cmd/*
+GOARCH=arm64 GOROOT=$GOROOT GOPATH=$EMPTY_TMPDIR GO111MODULE=on ./src/cmd/makebb/makebb $TMPDIR/gokrazy/cmd/* $TMPDIR/p9/cmd/*
+
+if grep -q -v "go1.13" <<< "$($GO version)"; then
+  GOARCH=riscv64 GOROOT=$GOROOT GOPATH=$EMPTY_TMPDIR GO111MODULE=on ./src/cmd/makebb/makebb $TMPDIR/gokrazy/cmd/* $TMPDIR/p9/cmd/*
+fi
+
+rm -rf $TMPDIR

--- a/test/nested/cmd/strace/strace.go
+++ b/test/nested/cmd/strace/strace.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux && amd64
 // +build linux,amd64
 
 // strace is a simple multi-process syscall & signal tracer.

--- a/vendortest/cmd/strace/strace.go
+++ b/vendortest/cmd/strace/strace.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux && amd64
 // +build linux,amd64
 
 // strace is a simple multi-process syscall & signal tracer.


### PR DESCRIPTION
This fixes Go module gobusybox builds across multiple modules, i.e. if you're building commands from e.g. both u-root and u-bmc.