### PR TITLE
Add basic findpkg unit tests

### DIFF
--- a/src/pkg/bb/findpkg/BUILD.bazel
+++ b/src/pkg/bb/findpkg/BUILD.bazel
@@ -18,4 +18,9 @@ go_test(
     name = "findpkg_test",
     srcs = ["bb_test.go"],
     embed = [":findpkg"],
+    deps = [
+        "//src/pkg/golang",
+        "@com_github_u_root_uio//ulog",
+        "@org_golang_x_tools//go/packages",
+    ],
 )

--- a/src/pkg/bb/findpkg/bb_test.go
+++ b/src/pkg/bb/findpkg/bb_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/uio/ulog"
+	"golang.org/x/tools/go/packages"
 )
 
 const (
@@ -209,6 +210,35 @@ func TestLoadFSPackages(t *testing.T) {
 			} else if (err != nil && tt.wantErr == nil) || (err == nil && tt.wantErr != nil) {
 				t.Errorf("loadFSPackages() err = %v, want: %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func TestAddPkg(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		pkg  packages.Package
+	}{
+		{
+			name: "empty package",
+			pkg:  packages.Package{},
+		},
+		{
+			name: "not main",
+			pkg: packages.Package{
+				Name:    "cmd",
+				GoFiles: []string{"cmd.go"},
+			},
+		},
+		{
+			name: "error",
+			pkg: packages.Package{
+				Errors: []packages.Error{{Msg: "error"}},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			addPkg(ulog.Null, nil, &tt.pkg)
 		})
 	}
 }

--- a/src/pkg/bb/findpkg/bb_test.go
+++ b/src/pkg/bb/findpkg/bb_test.go
@@ -5,11 +5,35 @@
 package findpkg
 
 import (
+	"go/build"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+	"text/template"
+
+	"github.com/u-root/gobusybox/src/pkg/golang"
+	"github.com/u-root/uio/ulog"
 )
+
+const (
+	modTemplate = `module {{ .ModPath }}
+
+go 1.16
+`
+
+	sourceTemplate = `package main
+
+func main() {
+	return
+}
+`
+)
+
+type module struct {
+	ModPath string
+}
 
 func TestModules(t *testing.T) {
 	dir := t.TempDir()
@@ -66,5 +90,125 @@ func TestModules(t *testing.T) {
 	}
 	if !reflect.DeepEqual(noModulePkgs, wantNoModule) {
 		t.Errorf("modules() no module pkgs = %v, want %v", noModulePkgs, wantNoModule)
+	}
+}
+
+func TestLoadFSPackages(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		modules  string
+		paths    []string
+		modFiles []string
+		goFiles  []string
+		wantErr  error
+	}{
+		{
+			name:    "modules",
+			modules: "on",
+			paths: []string{
+				"mod1/cmd/cmd1",
+				"mod1/cmd/cmd2",
+				"mod1/nestedmod1/cmd/cmd5",
+				"mod1/nestedmod2/cmd/cmd6",
+				"mod2/cmd/cmd3",
+				"mod2/cmd/cmd4",
+			},
+			modFiles: []string{
+				"mod1/go.mod",
+				"mod1/nestedmod1/go.mod",
+				"mod1/nestedmod2/go.mod",
+				"mod2/go.mod",
+			},
+			goFiles: []string{
+				"mod1/cmd/cmd1/main.go",
+				"mod1/cmd/cmd2/main.go",
+				"mod1/nestedmod1/cmd/cmd5/main.go",
+				"mod1/nestedmod2/cmd/cmd6/main.go",
+				"mod2/cmd/cmd3/main.go",
+				"mod2/cmd/cmd4/main.go",
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "no modules",
+			modules: "off",
+			paths: []string{
+				"nomod1/cmd/cmd1",
+				"nomod1/cmd/cmd2",
+				"nomod2/cmd/cmd3",
+				"nomod2/cmd/cmd4",
+			},
+			modFiles: []string{},
+			goFiles: []string{
+				"nomod1/cmd/cmd1/main.go",
+				"nomod1/cmd/cmd2/main.go",
+				"nomod2/cmd/cmd3/main.go",
+				"nomod2/cmd/cmd4/main.go",
+			},
+			wantErr: nil,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set temporary working dir and environment
+			dir := t.TempDir()
+			env := golang.Environ{
+				Context:     build.Default,
+				GO111MODULE: tt.modules,
+			}
+
+			// Create temoprary folder structure
+			paths := make([]string, len(tt.paths))
+			for i, path := range tt.paths {
+				paths[i] = filepath.Join(dir, path)
+				if err := os.MkdirAll(paths[i], 0o755); err != nil {
+					t.Errorf("Failed to create dir: %v", err)
+				}
+			}
+
+			// Set go.mod file template to replace the module path later
+			tmpl, err := template.New("mod").Parse(modTemplate)
+			if err != nil {
+				t.Errorf("Failed to parse template: %v", err)
+			}
+
+			// Create corresponding go.mod files and fill in the template
+			modFiles := make([]string, len(tt.modFiles))
+			for i, file := range tt.modFiles {
+				modFiles[i] = filepath.Join(dir, file)
+				f, err := os.Create(modFiles[i])
+				if err != nil {
+					t.Errorf("Failed to create file: %v", err)
+				}
+
+				if err := tmpl.Execute(f, module{
+					ModPath: strings.TrimPrefix(filepath.Dir(modFiles[i]), "/tmp/"),
+				}); err != nil {
+					t.Errorf("Failed writing to file: %v", err)
+				}
+
+				if err := f.Close(); err != nil {
+					t.Errorf("Failed to close file: %v", err)
+				}
+			}
+
+			// Create main.go files
+			goFiles := make([]string, len(tt.goFiles))
+			for i, file := range tt.goFiles {
+				goFiles[i] = filepath.Join(dir, file)
+				if err := os.WriteFile(goFiles[i], []byte(sourceTemplate), 0o644); err != nil {
+					t.Errorf("Failed to create file: %v", err)
+				}
+			}
+
+			// Call into function to test
+			// TODO(MDr164): We should probably use errors.Is() but then we need gloabl error objects
+			if _, err := loadFSPackages(ulog.Null, env, paths); err != nil && tt.wantErr != nil {
+				if !strings.Contains(err.Error(), tt.wantErr.Error()) {
+					t.Errorf("loadFSPackages() err = %v, want: %v", err, tt.wantErr)
+				}
+			} else if (err != nil && tt.wantErr == nil) || (err == nil && tt.wantErr != nil) {
+				t.Errorf("loadFSPackages() err = %v, want: %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/src/pkg/bb/findpkg/bb_test.go
+++ b/src/pkg/bb/findpkg/bb_test.go
@@ -5,7 +5,6 @@
 package findpkg
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,24 +12,7 @@ import (
 )
 
 func TestModules(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-modules-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	os.MkdirAll(filepath.Join(dir, "mod1/cmd/cmd1"), 0755)
-	os.MkdirAll(filepath.Join(dir, "mod1/cmd/cmd2"), 0755)
-	os.MkdirAll(filepath.Join(dir, "mod1/nestedmod1/cmd/cmd5"), 0755)
-	os.MkdirAll(filepath.Join(dir, "mod1/nestedmod2/cmd/cmd6"), 0755)
-	os.MkdirAll(filepath.Join(dir, "mod2/cmd/cmd3"), 0755)
-	os.MkdirAll(filepath.Join(dir, "mod2/cmd/cmd4"), 0755)
-	os.MkdirAll(filepath.Join(dir, "nomod/cmd/cmd7"), 0755)
-	ioutil.WriteFile(filepath.Join(dir, "mod1/go.mod"), nil, 0644)
-	ioutil.WriteFile(filepath.Join(dir, "mod1/nestedmod1/go.mod"), nil, 0644)
-	ioutil.WriteFile(filepath.Join(dir, "mod1/nestedmod2/go.mod"), nil, 0644)
-	ioutil.WriteFile(filepath.Join(dir, "mod2/go.mod"), nil, 0644)
-
+	dir := t.TempDir()
 	paths := []string{
 		filepath.Join(dir, "mod1/cmd/cmd1"),
 		filepath.Join(dir, "mod1/cmd/cmd2"),
@@ -40,6 +22,24 @@ func TestModules(t *testing.T) {
 		filepath.Join(dir, "mod2/cmd/cmd4"),
 		filepath.Join(dir, "nomod/cmd/cmd7"),
 	}
+	files := []string{
+		filepath.Join(dir, "mod1/go.mod"),
+		filepath.Join(dir, "mod1/nestedmod1/go.mod"),
+		filepath.Join(dir, "mod1/nestedmod2/go.mod"),
+		filepath.Join(dir, "mod2/go.mod"),
+	}
+
+	for _, path := range paths {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Errorf("Failed to create dir: %v", err)
+		}
+	}
+	for _, file := range files {
+		if err := os.WriteFile(file, nil, 0o644); err != nil {
+			t.Errorf("Failed to create file: %v", err)
+		}
+	}
+
 	mods, noModulePkgs := modules(paths)
 
 	want := map[string][]string{


### PR DESCRIPTION
This adds a few basic unit tests to findpkg. I'd like some feedback if the test structure is alright before probing for more error cases. Right now ´go test -cover´ reports 88.8% for that pkg.