### PR TITLE
loadFSPackages: do not ignore errors from addPkg

### DIFF
--- a/src/pkg/bb/findpkg/bb.go
+++ b/src/pkg/bb/findpkg/bb.go
@@ -88,6 +88,9 @@ func loadFSPackages(l ulog.Logger, env golang.Environ, filesystemPaths []string)
 		}
 		for _, pkg := range pkgs {
 			allps, err = addPkg(l, allps, pkg)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -100,6 +103,9 @@ func loadFSPackages(l ulog.Logger, env golang.Environ, filesystemPaths []string)
 		}
 		for _, p := range vendoredPkgs {
 			allps, err = addPkg(l, allps, p)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return allps, nil


### PR DESCRIPTION
loadFSPackages is currently ignoring errors returned by addPkg.

This results in a very bad outcome: firmware images that are missing commands.
For example, if you corrupt, e.g., date, u-root will still build
a firmware image with date missing.

This has, in turn, resulted in the creation of broken images (found in
the wild for those of us using cpu).

There is now a test in u-root specifically for the case that
this error is ignored (https://github.com/u-root/u-root/pull/2451)
and this fix makes that new test work, where it does not pass
currently.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>