### PR TITLE
use BuildTags in find package step

### DIFF
--- a/src/pkg/bb/findpkg/bb.go
+++ b/src/pkg/bb/findpkg/bb.go
@@ -265,6 +265,10 @@ func loadPkgs(env golang.Environ, dir string, patterns ...string) ([]*packages.P
 		Env:  append(os.Environ(), env.Env()...),
 		Dir:  dir,
 	}
+	if len(env.Context.BuildTags) > 0 {
+		tags := fmt.Sprintf("-tags=%s", strings.Join(env.Context.BuildTags, ","))
+		cfg.BuildFlags = []string{tags}
+	}
 	return packages.Load(cfg, patterns...)
 }
 


### PR DESCRIPTION
If a user sets, e.g., -tags tinygo, that tag must be used in the loadPkgs step, as well as the build step, else directories will be populated with files that can not be used.

Example: if we run
u-root -tags tinygo

files are copied to the build directory that should not be, and build steps will get an error.

With this change, tags will control both the file copy step as well as the build step.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>