### PR TITLE
API: improve golang.Default

### DIFF
--- a/src/pkg/bb/bb.go
+++ b/src/pkg/bb/bb.go
@@ -68,7 +68,7 @@ func checkDuplicate(cmds []*bbinternal.Package) error {
 type Opts struct {
 	// Env are the environment variables used in Go compilation and package
 	// discovery.
-	Env golang.Environ
+	Env *golang.Environ
 
 	// LookupEnv is the environment for looking up and resolving command
 	// paths.
@@ -116,6 +116,8 @@ type Opts struct {
 func BuildBusybox(l ulog.Logger, opts *Opts) (nerr error) {
 	if opts == nil {
 		return fmt.Errorf("no options given for busybox build")
+	} else if opts.Env == nil {
+		return fmt.Errorf("Go build environment unspecified for busybox build")
 	} else if err := opts.Env.Valid(); err != nil {
 		return err
 	}
@@ -586,7 +588,7 @@ func moduleVersionIdentifier(m *packages.Module) string {
 //
 // Then, in the generated tree's main module, we create a go.mod file with
 // replace directives for all the local modules we just copied over.
-func copyLocalDeps(l ulog.Logger, env golang.Environ, bbDir, tmpDir, pkgDir string, mainPkgs []*bbinternal.Package) error {
+func copyLocalDeps(l ulog.Logger, env *golang.Environ, bbDir, tmpDir, pkgDir string, mainPkgs []*bbinternal.Package) error {
 	localModules, err := findLocalModules(l, mainPkgs)
 	if err != nil {
 		return err

--- a/src/pkg/golang/build.go
+++ b/src/pkg/golang/build.go
@@ -58,14 +58,56 @@ func parseBool(s string) bool {
 	return ok
 }
 
+// Opt is an option function applied to Environ.
+type Opt func(*Environ)
+
+// DisableCGO is an option that disables cgo.
+func DisableCGO() Opt {
+	return func(c *Environ) {
+		c.CgoEnabled = false
+	}
+}
+
+// WithGOARCH is an option that overrides GOARCH.
+func WithGOARCH(goarch string) Opt {
+	return func(c *Environ) {
+		c.GOARCH = goarch
+	}
+}
+
+// WithGOPATH is an option that overrides GOPATH.
+func WithGOPATH(gopath string) Opt {
+	return func(c *Environ) {
+		c.GOPATH = gopath
+	}
+}
+
+// WithGOROOT is an option that overrides GOROOT.
+func WithGOROOT(goroot string) Opt {
+	return func(c *Environ) {
+		c.GOROOT = goroot
+	}
+}
+
+// WithGO111MODULE is an option that overrides GO111MODULE.
+func WithGO111MODULE(go111module string) Opt {
+	return func(c *Environ) {
+		c.GO111MODULE = go111module
+	}
+}
+
 // Default is the default build environment comprised of the default GOPATH,
 // GOROOT, GOOS, GOARCH, and CGO_ENABLED values.
-func Default() Environ {
-	return Environ{
+func Default(opt ...Opt) *Environ {
+	env := &Environ{
 		Context:     build.Default,
 		GO111MODULE: os.Getenv("GO111MODULE"),
 		GBBDEBUG:    parseBool(os.Getenv("GBBDEBUG")),
 	}
+	for _, o := range opt {
+		o(env)
+	}
+	return env
 }
 
 // GoCmd runs a go command in the environment.


### PR DESCRIPTION
Instead of the clunky

env := golang.Default()
env.CgoEnabled = false
env.GOARCH = ...

Then using &env somewhere like in u-root, we now have a nicer With* API that should allow all this in one line:

env := golang.Default(golang.DisableCGO(), golang.WithGOARCH("arm"))