### PR TITLE
golang: provide common packages.Load API

### DIFF
--- a/gobuilds-gopath.sh
+++ b/gobuilds-gopath.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eux
 
+(cd src && GO111MODULE=on go mod vendor)
+
 # all the go module builds should still work in $GOPATH
 ./gobuilds.sh
 

--- a/src/pkg/bb/findpkg/bb.go
+++ b/src/pkg/bb/findpkg/bb.go
@@ -263,16 +263,8 @@ func NewPackages(l ulog.Logger, genv *golang.Environ, env Env, names ...string) 
 }
 
 func loadPkgs(env *golang.Environ, dir string, patterns ...string) ([]*packages.Package, error) {
-	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedImports | packages.NeedFiles | packages.NeedDeps | packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedCompiledGoFiles | packages.NeedModule | packages.NeedEmbedFiles,
-		Env:  append(os.Environ(), env.Env()...),
-		Dir:  dir,
-	}
-	if len(env.Context.BuildTags) > 0 {
-		tags := fmt.Sprintf("-tags=%s", strings.Join(env.Context.BuildTags, ","))
-		cfg.BuildFlags = []string{tags}
-	}
-	return packages.Load(cfg, patterns...)
+	mode := packages.NeedName | packages.NeedImports | packages.NeedFiles | packages.NeedDeps | packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedCompiledGoFiles | packages.NeedModule | packages.NeedEmbedFiles
+	return env.Lookup(mode, dir, patterns...)
 }
 
 func filterDirectoryPaths(l ulog.Logger, env *golang.Environ, directories []string, excludes []string) ([]string, error) {
@@ -358,12 +350,7 @@ func excludePaths(paths []string, exclusions []string) []string {
 
 // Just looking up the stuff that doesn't take forever to parse.
 func lookupPkgNameAndFiles(env *golang.Environ, dir string, patterns ...string) ([]*packages.Package, error) {
-	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedFiles,
-		Env:  append(os.Environ(), env.Env()...),
-		Dir:  dir,
-	}
-	return packages.Load(cfg, patterns...)
+	return env.Lookup(packages.NeedName|packages.NeedFiles, dir, patterns...)
 }
 
 func couldBeGlob(s string) bool {

--- a/src/pkg/golang/BUILD.bazel
+++ b/src/pkg/golang/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["build.go"],
     importpath = "github.com/u-root/gobusybox/src/pkg/golang",
     visibility = ["//visibility:public"],
-    deps = ["//src/pkg/uflag"],
+    deps = [
+        "//src/pkg/uflag",
+        "@org_golang_x_tools//go/packages",
+    ],
 )

--- a/src/pkg/golang/build.go
+++ b/src/pkg/golang/build.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/u-root/gobusybox/src/pkg/uflag"
+	"golang.org/x/tools/go/packages"
 )
 
 // Environ are the environment variables for the Go compiler.
@@ -108,6 +109,20 @@ func Default(opt ...Opt) *Environ {
 		o(env)
 	}
 	return env
+}
+
+// Lookup looks up packages by patterns relative to dir, using the Go environment from c.
+func (c *Environ) Lookup(mode packages.LoadMode, dir string, patterns ...string) ([]*packages.Package, error) {
+	cfg := &packages.Config{
+		Mode: mode,
+		Env:  append(os.Environ(), c.Env()...),
+		Dir:  dir,
+	}
+	if len(c.Context.BuildTags) > 0 {
+		tags := fmt.Sprintf("-tags=%s", strings.Join(c.Context.BuildTags, ","))
+		cfg.BuildFlags = []string{tags}
+	}
+	return packages.Load(cfg, patterns...)
 }
 
 // GoCmd runs a go command in the environment.


### PR DESCRIPTION
Make sure that build tags are provided in every call to packages.Load by providing one common API, also usable by external callers.