### PR TITLE
Make Exit an overrideable package variable

### DIFF
--- a/src/pkg/bb/bbmain/cmd/main.go
+++ b/src/pkg/bb/bbmain/cmd/main.go
@@ -67,7 +67,7 @@ func ResolveUntilLastSymlink(p string) string {
 	return p
 }
 
-func run() {
+func run() int {
 	name := filepath.Base(os.Args[0])
 	err := bbmain.Run(name)
 	if errors.Is(err, bbmain.ErrNotRegistered) {
@@ -84,15 +84,23 @@ func run() {
 		for _, cmd := range bbmain.ListCmds() {
 			log.Printf(" - %s", cmd)
 		}
-		os.Exit(1)
-	} else if err != nil {
+		return 1
+	} 
+	if err != nil {
 		log.SetFlags(0)
-		log.Fatalf("Failed to run command: %v", err)
+		log.Printf("Failed to run command: %v", err)
+		return 1
 	}
+	return 0
 }
 
 func main() {
-	os.Args[0] = ResolveUntilLastSymlink(os.Args[0])
+	// This for loop will normally run once and Exit.
+	// In the case of bare metal environments, which can override
+	// Exit, it will run forever.
+	for {
+		os.Args[0] = ResolveUntilLastSymlink(os.Args[0])
 
-	run()
+		bbmain.Exit(run())
+	}
 }

--- a/src/pkg/bb/bbmain/register.go
+++ b/src/pkg/bb/bbmain/register.go
@@ -22,6 +22,10 @@ var ErrNotRegistered = errors.New("command is not present in busybox")
 // Noop is a noop function.
 var Noop = func() {}
 
+// Exit is called on Exit, and defaults to os.Exit
+// Bare metal environments can override it.
+var Exit = os.Exit
+
 // ListCmds returns all supported commands.
 func ListCmds() []string {
 	var cmds []string
@@ -60,7 +64,7 @@ func RegisterDefault(init, main func()) {
 
 // Run runs the command with the given name.
 //
-// If the command's main exits without calling os.Exit, Run will exit with exit
+// If the command's main exits without calling Exit, Run will exit with exit
 // code 0.
 func Run(name string) error {
 	var cmd *bbCmd
@@ -73,7 +77,7 @@ func Run(name string) error {
 	}
 	cmd.init()
 	cmd.main()
-	os.Exit(0)
+	Exit(0)
 	// Unreachable.
 	return nil
 }


### PR DESCRIPTION
In bare metal environments such as Tamago,
os.Exit halts the machine.

Add a variable, Exit, to the bbmain package.
The default value is os.Exit.

Have main() in bbmain run a for loop, which calls
bbmain.Exit with the return value of run().

change run() to return the value, not call os.Exit.

These changes should make no difference in Linux, but in tinygo and Tamago environments it will be possible to ensure that the main loop no longer exits.