### PR TITLE
Support shell expansion in API & gencmddeps tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,22 @@ import (
 )
 ```
 
+You can generate this file for your repo with the `gencmddeps` tool:
+
+```
+go install github.com/u-root/gobusybox/src/cmd/gencmddeps@latest
+
+gencmddeps -o deps.go -t tools -p something \
+    github.com/u-root/u-root/cmds/core/{ip,init} \
+    github.com/hugelgupf/p9/cmd/p9ufs
+```
+
+> [!IMPORTANT]
+> `gencmddeps` does not support file paths or exclusions, as these rely on a
+> `go.mod` already being present to resolve the Go package name.
+>
+> The input to gencmddeps must be full Go package paths.
+
 The unused build tag keeps it from being compiled, but its existence forces `go
 mod` to add these dependencies to `go.mod`:
 

--- a/src/cmd/gencmddeps/.gitignore
+++ b/src/cmd/gencmddeps/.gitignore
@@ -1,0 +1,1 @@
+gencmddeps

--- a/src/cmd/gencmddeps/main.go
+++ b/src/cmd/gencmddeps/main.go
@@ -1,0 +1,60 @@
+// gencmddeps generates a command dependency Go file.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"log"
+	"os"
+	"text/template"
+)
+
+var (
+	pkg = flag.String("p", "", "Package name")
+	o   = flag.String("o", "", "Output file name")
+	tag = flag.String("t", "", "Go build tag for the file")
+)
+
+func main() {
+	flag.Parse()
+
+	if *tag == "" {
+		log.Fatal("Must specify Go build tag")
+	}
+	if *pkg == "" {
+		log.Fatal("Must specify package name")
+	}
+	if *o == "" {
+		log.Fatal("Must specify output file name")
+	}
+	if flag.NArg() == 0 {
+		log.Fatalf("No commands to import given")
+	}
+
+	tpl := `//go:build {{.Tag}}
+
+package {{.Package}}
+
+import ({{range .Imports}}
+	_ "{{.}}"{{end}}
+)
+`
+
+	vars := struct {
+		Tag     string
+		Package string
+		Imports []string
+	}{
+		Tag:     *tag,
+		Package: *pkg,
+		Imports: flag.Args(),
+	}
+	t := template.Must(template.New("tpl").Parse(tpl))
+	var b bytes.Buffer
+	if err := t.Execute(&b, vars); err != nil {
+		log.Fatal(err)
+	}
+	if err := os.WriteFile(*o, b.Bytes(), 0o644); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/u-root/uio v0.0.0-20210528151154-e40b768296a7
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 	golang.org/x/tools v0.18.0
+	mvdan.cc/sh/v3 v3.7.0
 )
 
 require golang.org/x/mod v0.15.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,3 +1,8 @@
+github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/rogpeppe/go-internal v1.10.1-0.20230524175051-ec119421bb97 h1:3RPlVWzZ/PDqmVuf/FKHARG5EMid/tl7cv54Sw/QRVY=
 github.com/u-root/uio v0.0.0-20210528151154-e40b768296a7 h1:XMAtQHwKjWHIRwg+8Nj/rzUomQY1q6cM3ncA0wP8GU4=
 github.com/u-root/uio v0.0.0-20210528151154-e40b768296a7/go.mod h1:LpEX5FO/cB+WF4TYGY1V5qktpaZLkKkSegbr0V4eYXA=
 golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUFH7PGP+OQ6mgDYo3yuQ=
@@ -8,3 +13,5 @@ golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
 golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/tools v0.18.0 h1:k8NLag8AGHnn+PHbl7g43CtqZAwG60vZkLqgyZgIHgQ=
 golang.org/x/tools v0.18.0/go.mod h1:GL7B4CwcLLeo59yx/9UWWuNOW1n3VZ4f5axWfML7Lcg=
+mvdan.cc/sh/v3 v3.7.0 h1:lSTjdP/1xsddtaKfGg7Myu7DnlHItd3/M2tomOcNNBg=
+mvdan.cc/sh/v3 v3.7.0/go.mod h1:K2gwkaesF/D7av7Kxl0HbF5kGOd2ArupNTX3X44+8l8=

--- a/src/pkg/bb/findpkg/bb_test.go
+++ b/src/pkg/bb/findpkg/bb_test.go
@@ -233,8 +233,20 @@ func TestResolve(t *testing.T) {
 				"github.com/u-root/u-root/cmds/core/ip",
 			},
 		},
-		// TODO: vendored multi module?
-
+		// Shell expansions.
+		{
+			name: "pkgpath-shell-expansion",
+			envs: []*golang.Environ{moduleOnEnv},
+			wd:   filepath.Join(gbbroot, "test/resolve-modules"),
+			in: []string{
+				"github.com/u-root/u-root/cmds/core/{init,ip,dhclient}",
+			},
+			want: []string{
+				"github.com/u-root/u-root/cmds/core/dhclient",
+				"github.com/u-root/u-root/cmds/core/init",
+				"github.com/u-root/u-root/cmds/core/ip",
+			},
+		},
 		// Exclusion, single package, file system path.
 		{
 			name: "fspath-exclusion",


### PR DESCRIPTION
Users of the `pkg/bb` API may now specify shell expansions such as `github.com/u-root/u-root/cmds/core/{init,ip}`, and they will be expanded by mvdan.cc/sh's field expansion from https://pkg.go.dev/mvdan.cc/sh/v3@v3.8.0/shell#Fields (without expanding environment variables).

This will be useful in mkuimage templates.