### PR TITLE
tinygo: -compiler command line argument (e.g. tinygo)

### DIFF
--- a/src/cmd/makebb/makebb.go
+++ b/src/cmd/makebb/makebb.go
@@ -43,7 +43,14 @@ func main() {
 		l.Printf("Disabling CGO for u-root...")
 		env.CgoEnabled = false
 	}
+
+	err = env.InitCompiler()
+	if err != nil {
+		l.Fatal(err)
+	}
+
 	l.Printf("Build environment: %s", env)
+	l.Printf("Compiler: %s", env.Compiler.VersionOutput)
 
 	tmpDir := *genDir
 	remove := false

--- a/src/cmd/makebb/makebb.go
+++ b/src/cmd/makebb/makebb.go
@@ -49,8 +49,8 @@ func main() {
 		l.Fatal(err)
 	}
 
-	l.Printf("Build environment: %s", env)
-	l.Printf("Compiler: %s", env.Compiler.VersionOutput)
+	l.Printf("Build environment: %s\n", env)
+	l.Printf("Compiler: %s\n", env.Compiler.VersionOutput)
 
 	tmpDir := *genDir
 	remove := false

--- a/src/cmd/makebb/makebb.go
+++ b/src/cmd/makebb/makebb.go
@@ -44,7 +44,7 @@ func main() {
 		env.CgoEnabled = false
 	}
 
-	err = env.InitCompiler()
+	err = env.CompilerInit()
 	if err != nil {
 		l.Fatal(err)
 	}

--- a/src/pkg/golang/build.go
+++ b/src/pkg/golang/build.go
@@ -6,6 +6,7 @@
 package golang
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"go/build"
@@ -29,6 +30,15 @@ const (
 	ModVendor   ModBehavior = "vendor"
 )
 
+type Compiler struct {
+	Path          string
+	Identifier    string // e.g. 'tinygo' or 'go'
+	Version       string // compiler-tool version
+	VersionGo     string // version of go: same as 'Version' for standard go
+	VersionOutput string // output of calling 'tool version'
+	IsInit        bool   // InitCompiler() succeeded
+}
+
 // Environ are the environment variables for the Go compiler.
 type Environ struct {
 	build.Context
@@ -36,6 +46,8 @@ type Environ struct {
 	GO111MODULE string
 	Mod         ModBehavior
 	GBBDEBUG    bool
+
+	Compiler Compiler
 }
 
 // Copy makes a copy of Environ with the given changes.
@@ -45,6 +57,7 @@ func (c *Environ) Copy(opts ...Opt) *Environ {
 		GO111MODULE: c.GO111MODULE,
 		Mod:         c.Mod,
 		GBBDEBUG:    c.GBBDEBUG,
+		Compiler:    c.Compiler,
 	}
 	e.Apply(opts...)
 	return e
@@ -54,6 +67,8 @@ func (c *Environ) Copy(opts ...Opt) *Environ {
 func (c *Environ) RegisterFlags(f *flag.FlagSet) {
 	f.Var((*uflag.Strings)(&c.BuildTags), "go-build-tags", "Go build tags")
 	f.StringVar((*string)(&c.Mod), "go-mod", string(c.Mod), "Value of -mod to go commands (allowed: (empty), vendor, mod, readonly)")
+	f.StringVar((*string)(&c.Compiler.Path), "compiler", "",
+		"override go compiler to use (e.g. \"/path/to/tinygo\")")
 }
 
 // Valid returns an error if GOARCH, GOROOT, or GOOS are unset.
@@ -176,13 +191,16 @@ func (c *Environ) Apply(opts ...Opt) {
 
 // Lookup looks up packages by patterns relative to dir, using the Go environment from c.
 func (c *Environ) Lookup(mode packages.LoadMode, patterns ...string) ([]*packages.Package, error) {
+	if err := c.InitCompiler(); err != nil {
+		return nil, err
+	}
 	cfg := &packages.Config{
 		Mode: mode,
 		Env:  append(os.Environ(), c.Env()...),
 		Dir:  c.Dir,
 	}
 	if len(c.Context.BuildTags) > 0 {
-		tags := fmt.Sprintf("-tags=%s", strings.Join(c.Context.BuildTags, ","))
+		tags := fmt.Sprintf("-tags=%s", strings.Join(c.BuildTags, ","))
 		cfg.BuildFlags = []string{tags}
 	}
 	if c.GO111MODULE != "off" && len(c.Mod) > 0 {
@@ -193,7 +211,10 @@ func (c *Environ) Lookup(mode packages.LoadMode, patterns ...string) ([]*package
 
 // GoCmd runs a go command in the environment.
 func (c Environ) GoCmd(gocmd string, args ...string) *exec.Cmd {
-	goBin := filepath.Join(c.GOROOT, "bin", "go")
+	goBin := c.Compiler.Path
+	if "" == goBin {
+		goBin = filepath.Join(c.GOROOT, "bin", "go")
+	}
 	args = append([]string{gocmd}, args...)
 	cmd := exec.Command(goBin, args...)
 	if c.GBBDEBUG {
@@ -204,19 +225,107 @@ func (c Environ) GoCmd(gocmd string, args ...string) *exec.Cmd {
 	return cmd
 }
 
-// Version returns the Go version string that runtime.Version would return for
-// the Go compiler in this environ.
-func (c Environ) Version() (string, error) {
+// resolve absolute path of go-compiler option from PATH
+func (c *Environ) resolveCompiler() error {
+	if c.Compiler.Path != "" {
+		fname, err := exec.LookPath(string(c.Compiler.Path))
+		if err == nil {
+			fname, err = filepath.Abs(fname)
+		}
+		if err != nil {
+			return fmt.Errorf("build: %v", err)
+		}
+		c.Compiler.Path = fname
+	}
+	return nil
+}
+
+// runs GoCmd("version") and parse/caches output, to environ.Compiler
+func (c *Environ) InitCompiler() error {
+
+	if c.Compiler.IsInit {
+		return nil
+	}
+
+	c.resolveCompiler()
+
 	cmd := c.GoCmd("version")
 	v, err := cmd.CombinedOutput()
 	if err != nil {
+		return err
+	}
+
+	efmt := "go-compiler 'version' output unrecognized: %v"
+	s := strings.Fields(string(v))
+	if len(s) < 1 {
+		return fmt.Errorf(efmt, string(v))
+	}
+
+	compiler := c.Compiler
+	compiler.Identifier = s[0]
+	compiler.VersionOutput = string(v)
+	compiler.IsInit = true
+
+	switch compiler.Identifier {
+
+	case "go":
+		if len(s) < 3 {
+			return fmt.Errorf(efmt, string(v))
+		}
+		compiler.Version = s[2]
+		compiler.VersionGo = s[2]
+
+	case "tinygo":
+		// e.g. "tinygo version 0.33.0 darwin/arm64 (using go version go1.22.2 and LLVM version 18.1.2)"
+		if len(s) < 8 {
+			return fmt.Errorf(efmt, string(v))
+		}
+		compiler.Version = s[2]
+		compiler.VersionGo = s[7]
+
+		// Fetch additional go-build-tags from tinygo
+		// package fetch needs correct tags to prune
+		cmd := c.GoCmd("info", "-json")
+		infov, err := cmd.CombinedOutput()
+		if err != nil {
+			return err
+		}
+		var info map[string]interface{}
+		err = json.Unmarshal(infov, &info)
+		if err != nil {
+			return err
+		}
+		tags := []string{}
+		unique := make(map[string]bool)
+		addUnique := func(tag string) {
+			if unique[tag] {
+				return
+			}
+			unique[tag] = true
+			tags = append(tags, tag)
+		}
+		for _, tag := range c.BuildTags {
+			addUnique(tag)
+		}
+		for _, tag := range info["build_tags"].([]interface{}) {
+			addUnique(tag.(string))
+		}
+		c.BuildTags = tags
+
+	default:
+		return fmt.Errorf(efmt, string(v))
+	}
+	c.Compiler = compiler
+	return nil
+}
+
+// Version returns the Go version string that runtime.Version would return for
+// the Go compiler in this environ.
+func (c *Environ) Version() (string, error) {
+	if err := c.InitCompiler(); err != nil {
 		return "", err
 	}
-	s := strings.Fields(string(v))
-	if len(s) < 3 {
-		return "", fmt.Errorf("unknown go version, tool returned weird output for 'go version': %v", string(v))
-	}
-	return s[2], nil
+	return c.Compiler.VersionGo, nil
 }
 
 func (c Environ) envCommon() []string {
@@ -301,40 +410,69 @@ func (b *BuildOpts) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (c Environ) build(dirPath string, binaryPath string, pattern []string, opts *BuildOpts) error {
-	args := []string{
-		// Force rebuilding of packages.
-		"-a",
 
+	if err := c.InitCompiler(); err != nil {
+		return err
+	}
+
+	args := []string{
 		"-o", binaryPath,
 	}
+
 	if c.GO111MODULE != "off" && len(c.Mod) > 0 {
 		args = append(args, "-mod", string(c.Mod))
 	}
 	if c.InstallSuffix != "" {
 		args = append(args, "-installsuffix", c.Context.InstallSuffix)
 	}
-	if opts == nil || !opts.EnableInlining {
-		// Disable "function inlining" to get a (likely) smaller binary.
-		args = append(args, "-gcflags=all=-l")
+
+	switch c.Compiler.Identifier {
+	case "go":
+
+		// Force rebuilding of packages.
+		args = append(args, "-a")
+
+		if opts == nil || !opts.EnableInlining {
+			// Disable "function inlining" to get a (likely) smaller binary.
+			args = append(args, "-gcflags=all=-l")
+		}
+
+		if opts == nil || !opts.NoStrip {
+			// Strip all symbols, and don't embed a Go build ID to be reproducible.
+			args = append(args, "-ldflags", "-s -w -buildid=")
+		}
+
+		if opts == nil || !opts.NoTrimPath {
+			// Reproducible builds: Trim any GOPATHs out of the executable's
+			// debugging information.
+			//
+			// E.g. Trim /tmp/bb-*/ from /tmp/bb-12345567/src/github.com/...
+			args = append(args, "-trimpath")
+		}
+
+	case "tinygo":
+
+		// TODO: handle force-rebuild of packages (-a to standard go)
+		// TODO: handle EnableInlining
+
+		// Strip all symbols. TODO: not sure about buildid
+		if opts == nil || !opts.NoStrip {
+			// Strip all symbols
+			args = append(args, "-no-debug")
+		}
+
+		// TODO: handle NoTrimpPath
+
 	}
-	if opts == nil || !opts.NoStrip {
-		// Strip all symbols, and don't embed a Go build ID to be reproducible.
-		args = append(args, "-ldflags", "-s -w -buildid=")
+
+	if len(c.BuildTags) > 0 {
+		args = append(args, fmt.Sprintf("-tags=%s", strings.Join(c.BuildTags, ",")))
 	}
-	if opts == nil || !opts.NoTrimPath {
-		// Reproducible builds: Trim any GOPATHs out of the executable's
-		// debugging information.
-		//
-		// E.g. Trim /tmp/bb-*/ from /tmp/bb-12345567/src/github.com/...
-		args = append(args, "-trimpath")
-	}
+
 	if opts != nil {
 		args = append(args, opts.ExtraArgs...)
 	}
 
-	if len(c.BuildTags) > 0 {
-		args = append(args, []string{"-tags", strings.Join(c.BuildTags, " ")}...)
-	}
 	args = append(args, pattern...)
 
 	cmd := c.GoCmd("build", args...)

--- a/src/pkg/golang/build.go
+++ b/src/pkg/golang/build.go
@@ -168,6 +168,13 @@ func WithWorkingDir(wd string) Opt {
 	}
 }
 
+// WithCompiler sets the compiler for Build() / BuildDir()
+func WithCompiler(p string) Opt {
+	return func(c *Environ) {
+		c.Compiler.Path = p
+	}
+}
+
 // Default is the default build environment comprised of the default GOPATH,
 // GOROOT, GOOS, GOARCH, and CGO_ENABLED values.
 func Default(opts ...Opt) *Environ {

--- a/src/pkg/golang/compiler.go
+++ b/src/pkg/golang/compiler.go
@@ -1,0 +1,250 @@
+// Copyright 2015-2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package golang is an API to the Go compiler.
+package golang
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type CompilerType int
+
+const (
+	CompilerGo CompilerType = iota
+	CompilerTinygo
+	CompilerUnkown
+)
+
+// cached information re: the compiler
+type Compiler struct {
+	Path          string
+	Identifier    string // e.g. 'tinygo' or 'go'
+	Type          CompilerType
+	Version       string // compiler-tool version, e.g. '0.32.0' for tinygo, go1.22.2 for
+	VersionGo     string // version of go: same as 'Version' for standard go
+	VersionOutput string // output of calling 'tool version'
+	IsInit        bool   // CompilerInit() succeeded
+}
+
+// map the compiler's identifier ("tinygo" or "go") to enum
+func CompilerTypeFromString(name string) CompilerType {
+	val, ok := map[string]CompilerType{
+		"go":     CompilerGo,
+		"tinygo": CompilerTinygo,
+	}[name]
+	if ok {
+		return val
+	}
+	return CompilerUnkown
+}
+
+// WithCompiler sets the compiler for Build() / BuildDir()
+func WithCompiler(p string) Opt {
+	return func(c *Environ) {
+		c.Compiler.Path = p
+		c.Compiler.IsInit = false
+	}
+}
+
+// compilerCmd returns a compiler command to be run in the environment.
+func (c Environ) compilerCmd(gocmd string, args ...string) *exec.Cmd {
+	goBin := c.Compiler.Path
+	if "" == goBin {
+		goBin = filepath.Join(c.GOROOT, "bin", "go")
+	}
+	args = append([]string{gocmd}, args...)
+	cmd := exec.Command(goBin, args...)
+	if c.GBBDEBUG {
+		log.Printf("GBB Go invocation: %s %s %#v", c, goBin, args)
+	}
+	cmd.Dir = c.Dir
+	cmd.Env = append(os.Environ(), c.Env()...)
+	return cmd
+}
+
+// if go-compiler specified, resolve absolute-path from PATH,
+// otherwise return 'nil'.
+func (c *Environ) compilerAbs() error {
+	if c.Compiler.Path != "" {
+		fname, err := exec.LookPath(string(c.Compiler.Path))
+		if err == nil {
+			fname, err = filepath.Abs(fname)
+		}
+		if err != nil {
+			return fmt.Errorf("build: %v", err)
+		}
+		c.Compiler.Path = fname
+	}
+	return nil
+}
+
+// runs compilerCmd("version") and parse/caches output, to environ.Compiler
+func (c *Environ) CompilerInit() error {
+
+	if c.Compiler.IsInit {
+		return nil
+	}
+
+	c.compilerAbs()
+
+	cmd := c.compilerCmd("version")
+	v, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	efmt := "go-compiler 'version' output unrecognized: %v"
+	s := strings.Fields(string(v))
+	if len(s) < 1 {
+		return fmt.Errorf(efmt, string(v))
+	}
+
+	compiler := c.Compiler
+	compiler.VersionOutput = string(v)
+	compiler.Identifier = s[0]
+	compiler.Type = CompilerTypeFromString(compiler.Identifier)
+	compiler.IsInit = true
+
+	switch compiler.Type {
+
+	case CompilerGo:
+		if len(s) < 3 {
+			return fmt.Errorf(efmt, string(v))
+		}
+		compiler.Version = s[2]
+		compiler.VersionGo = s[2]
+
+	case CompilerTinygo:
+		// e.g. "tinygo version 0.33.0 darwin/arm64 (using go version go1.22.2 and LLVM version 18.1.2)"
+		if len(s) < 8 {
+			return fmt.Errorf(efmt, string(v))
+		}
+		compiler.Version = s[2]
+		compiler.VersionGo = s[7]
+
+		// Fetch additional go-build-tags from tinygo
+		// package fetch needs correct tags to prune
+		cmd := c.compilerCmd("info", "-json")
+		infov, err := cmd.CombinedOutput()
+		if err != nil {
+			return err
+		}
+		var info map[string]interface{}
+		err = json.Unmarshal(infov, &info)
+		if err != nil {
+			return err
+		}
+
+		// extract unique build tags
+		tags := make(map[string]struct{})
+		for _, tag := range c.BuildTags {
+			tags[tag] = struct{}{}
+		}
+		for _, tag := range info["build_tags"].([]interface{}) {
+			tags[tag.(string)] = struct{}{}
+		}
+		for tag := range tags {
+			c.BuildTags = append(c.BuildTags, tag)
+		}
+
+	case CompilerUnkown:
+		return fmt.Errorf(efmt, string(v))
+	}
+	c.Compiler = compiler
+	return nil
+}
+
+// Version returns the Go version string that runtime.Version would return for
+// the Go compiler in this environ.
+func (c *Environ) Version() (string, error) {
+	if err := c.CompilerInit(); err != nil {
+		return "", err
+	}
+	return c.Compiler.VersionGo, nil
+}
+
+func (c Environ) build(dirPath string, binaryPath string, pattern []string, opts *BuildOpts) error {
+
+	if err := c.CompilerInit(); err != nil {
+		return err
+	}
+
+	args := []string{
+		"-o", binaryPath,
+	}
+
+	if c.GO111MODULE != "off" && len(c.Mod) > 0 {
+		args = append(args, "-mod", string(c.Mod))
+	}
+	if c.InstallSuffix != "" {
+		args = append(args, "-installsuffix", c.Context.InstallSuffix)
+	}
+
+	switch c.Compiler.Type {
+	case CompilerGo:
+
+		// Force rebuilding of packages.
+		args = append(args, "-a")
+
+		if opts == nil || !opts.EnableInlining {
+			// Disable "function inlining" to get a (likely) smaller binary.
+			args = append(args, "-gcflags=all=-l")
+		}
+
+		if opts == nil || !opts.NoStrip {
+			// Strip all symbols, and don't embed a Go build ID to be reproducible.
+			args = append(args, "-ldflags", "-s -w -buildid=")
+		}
+
+		if opts == nil || !opts.NoTrimPath {
+			// Reproducible builds: Trim any GOPATHs out of the executable's
+			// debugging information.
+			//
+			// E.g. Trim /tmp/bb-*/ from /tmp/bb-12345567/src/github.com/...
+			args = append(args, "-trimpath")
+		}
+
+	case CompilerTinygo:
+
+		// TODO: handle force-rebuild of packages (-a to standard go)
+		// TODO: handle EnableInlining
+
+		// Strip all symbols. TODO: not sure about buildid
+		if opts == nil || !opts.NoStrip {
+			// Strip all symbols
+			args = append(args, "-no-debug")
+		}
+
+		// TODO: handle NoTrimpPath
+
+	}
+
+	if len(c.BuildTags) > 0 {
+		args = append(args, fmt.Sprintf("-tags=%s", strings.Join(c.BuildTags, ",")))
+	}
+
+	if opts != nil {
+		args = append(args, opts.ExtraArgs...)
+	}
+
+	args = append(args, pattern...)
+
+	cmd := c.compilerCmd("build", args...)
+	if dirPath != "" {
+		cmd.Dir = dirPath
+	}
+
+	if o, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("error building go package in %q: %v, %v", dirPath, string(o), err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
help: 
- ~~I haven't figured out how to propagate this to mkuimage.~~
- it may make more sense as a buildopt instead of environ in build.go(?)
  - but the BuildOpts isn't always available
- name of flag? -go-compiler(?)
- any feedback! 

This allows specifying the compiler explicitly in makebb and handles peculiarities of tinygo.  It works by resolving and caching the path to the go-compiler then queries tinygo for its hidden go-build-tags and propagates them to package lookup / install. This allows the pruning algorithm to correctly add / remove files when syncing dependent packages.

Usage:
```
% makebb -h 
Usage of makebb:
  -compiler string
    	override go compiler to use (e.g. "/path/to/tinygo")
[...]
```
Resulting busybox is significantly smaller.  I compiled a slightly more complicated project than e.g. u-root/cmds/core/{true,false} to test package resolution.

Standard go:
```sh
u-root % GOOS=linux makebb cmds/core/init
10:10:54 Build environment: GOARCH=arm64 GOOS=linux GOPATH=/Users/roger/go CGO_ENABLED=0 GO111MODULE= GOROOT=/opt/homebrew/Cellar/go/1.22.2/libexec PATH=/opt/homebrew/Cellar/go/1.22.2/libexec/bin
10:10:54 Compiler: go version go1.22.2 darwin/arm64
10:10:59 Successfully built "bb" (size 2556039 bytes -- 2.4 MiB). <============
```

tinygo:
```sh
u-root % GOOS=linux makebb -compiler tinygo cmds/core/init
10:10:06 Build environment: GOARCH=arm64 GOOS=linux GOPATH=/Users/roger/go CGO_ENABLED=0 GO111MODULE= GOROOT=/opt/homebrew/Cellar/go/1.22.2/libexec PATH=/opt/homebrew/Cellar/go/1.22.2/libexec/bin
10:10:06 Compiler: tinygo version 0.33.0-dev-6184a6cd darwin/arm64 (using go version go1.22.2 and LLVM version 18.1.2)
10:10:20 Successfully built "bb" (size 1408888 bytes -- 1.3 MiB).  <============
```

Needs:
- tinygo dev branch (for syscall fixes supplied by @leongross )
- this patch to u-root to compile (link) with tinygo
- (rebased) tinygo-org/tinygo#4273

```
diff --git a/cmds/core/init/fns_other.go b/cmds/core/init/fns_other.go
index 850ce067..f979aaea 100644
--- a/cmds/core/init/fns_other.go
+++ b/cmds/core/init/fns_other.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !tinygo && !(darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
-// +build !tinygo,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+//go:build !(darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
+// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
 
 package main
 
diff --git a/cmds/core/init/fns_unix.go b/cmds/core/init/fns_unix.go
index 4bcac715..4db8d9d0 100644
--- a/cmds/core/init/fns_unix.go
+++ b/cmds/core/init/fns_unix.go
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !tinygo && (darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
-// +build !tinygo
+//go:build (darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main
diff --git a/cmds/core/init/init_plan9.go b/cmds/core/init/init_plan9.go
index 4fb93f94..6b88f159 100644
--- a/cmds/core/init/init_plan9.go
+++ b/cmds/core/init/init_plan9.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !tinygo && plan9
-// +build !tinygo,plan9
+//go:build plan9
+// +build plan9
 
 package main
 
diff --git a/cmds/core/init/init_tinygo.go b/cmds/core/init/init_tinygo.go
new file mode 100644
index 00000000..1d670023
--- /dev/null
+++ b/cmds/core/init/init_tinygo.go
@@ -0,0 +1,29 @@
+//go:build tinygo
+
+package main
+
+/*
+ld.lld: error: undefined symbol: syscall.runtime_BeforeExec
+>>> referenced by exec_unix.go:282 ([...]/go/1.22.2/libexec/src/syscall/exec_unix.go:282)
+>>>               /var/folders/7f/_6cnvk8j475gw2rk8q3hv8q00000gn/T/tinygo3894403787/main.lto.main.o:(runtime.run$1$gowrapper)
+
+ld.lld: error: undefined symbol: syscall.runtime_AfterExec
+>>> referenced by exec_unix.go:308 ([...]/go/1.22.2/libexec/src/syscall/exec_unix.go:308)
+>>>               /var/folders/7f/_6cnvk8j475gw2rk8q3hv8q00000gn/T/tinygo3894403787/main.lto.main.o:(runtime.run$1$gowrapper)
+failed to run tool: ld.lld
+failed to link /var/folders/7f/_6cnvk8j475gw2rk8q3hv8q00000gn/T/tinygo3894403787/main: exit status 1
+*/
+
+import (
+	_ "unsafe" // for go:linkname
+)
+
+//go:linkname runtime_BeforeExec syscall.runtime_BeforeExec
+func runtime_BeforeExec() {
+
+}
+
+//go:linkname runtime_AfterExec syscall.runtime_AfterExec
+func runtime_AfterExec() {
+
+}
```
