### PR TITLE
Restore GoCmd for Environ

### DIFF
--- a/src/pkg/golang/compiler.go
+++ b/src/pkg/golang/compiler.go
@@ -54,6 +54,12 @@ func WithCompiler(p string) Opt {
 	}
 }
 
+// GoCmd runs a go command. It is used by, among other things, u-root testing
+// for such things as go tool.
+func (c Environ) GoCmd(gocmd string, args ...string) *exec.Cmd {
+	return c.compilerCmd(gocmd, args...)
+}
+
 // Returns a compiler command to be run in the environment.
 func (c Environ) compilerCmd(gocmd string, args ...string) *exec.Cmd {
 	goBin := c.Compiler.Path

--- a/src/pkg/golang/compiler_test.go
+++ b/src/pkg/golang/compiler_test.go
@@ -1,0 +1,13 @@
+// Copyright 2015-2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package golang is an API to the Go compiler.
+package golang
+
+import "testing"
+
+// TestUrootUsage makes sure that no changes break u-root.
+func TestUrootUsage(t *testing.T) {
+	_ = Default().GoCmd("tool", "doc", "fmt")
+}


### PR DESCRIPTION
External code such as u-root depend on its existence.

Done this way in case someone wants to further change things.