### PR TITLE
Lock mvdan/sh to v3.11.0

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90
 	golang.org/x/tools v0.43.0
-	mvdan.cc/sh/v3 v3.13.0
+	mvdan.cc/sh/v3 v3.11.0
 )
 
 require (

--- a/src/go.sum
+++ b/src/go.sum
@@ -24,5 +24,5 @@ golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
-mvdan.cc/sh/v3 v3.13.0 h1:dSfq/MVsY4w0Vsi6Lbs0IcQquMVqLdKLESAOZjuHdLg=
-mvdan.cc/sh/v3 v3.13.0/go.mod h1:KV1GByGPc/Ho0X1E6Uz9euhsIQEj4hwyKnodLlFLoDM=
+mvdan.cc/sh/v3 v3.11.0 h1:q5h+XMDRfUGUedCqFFsjoFjrhwf2Mvtt1rkMvVz0blw=
+mvdan.cc/sh/v3 v3.11.0/go.mod h1:LRM+1NjoYCzuq/WZ6y44x14YNAI0NK7FLPeQSaFagGg=


### PR DESCRIPTION
v3.13 has a serious bug, which is that it names kill as a builtin but does not implement it.

Which would not be a problem, save than mkuimage imports gobusybox, and that cascades to u-root, and u-root ends up using v3.13.1 of mvdan/sh, which has the bug.

It would be much better, I suspect, to stop using shell.Fields in gobusybox, and just forgo having working shell expansion.

Using mvdan/sh in gobusybox causes trouble 2 repos to our left ...